### PR TITLE
fixed bug in ProcessManifest which is due to Integer.getInteger

### DIFF
--- a/src/soot/jimple/infoflow/android/manifest/ProcessManifest.java
+++ b/src/soot/jimple/infoflow/android/manifest/ProcessManifest.java
@@ -400,7 +400,7 @@ public class ProcessManifest {
 	 */
 	public int getVersionCode() {
 		AXmlAttribute<?> attr = this.manifest.getAttribute("versionCode");
-		return attr == null ? -1 : Integer.getInteger((String) attr.getValue());
+		return attr == null ? -1 : Integer.parseInt("" + attr.getValue());
 	}
 	
 	/**
@@ -446,7 +446,7 @@ public class ProcessManifest {
 		if (attr.getValue() instanceof Integer)
 			return (Integer) attr.getValue();
 		
-		return Integer.getInteger((String) attr.getValue());		
+		return Integer.parseInt("" + attr.getValue());		
 	}
 	
 	/**
@@ -465,7 +465,7 @@ public class ProcessManifest {
 		if (attr.getValue() instanceof Integer)
 			return (Integer) attr.getValue();
 		
-		return Integer.getInteger((String) attr.getValue());		
+		return Integer.parseInt("" + attr.getValue());		
 	}
 	
 	/**

--- a/test/soot/jimple/infoflow/android/test/manifest/ProcessManifestTest.java
+++ b/test/soot/jimple/infoflow/android/test/manifest/ProcessManifestTest.java
@@ -1,0 +1,70 @@
+package soot.jimple.infoflow.android.test.manifest;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParserException;
+
+import soot.jimple.infoflow.android.manifest.ProcessManifest;
+
+public class ProcessManifestTest 
+{
+	@Test
+	public void testGetVersionCode()
+	{
+		ProcessManifest manifest = null;
+		
+		try 
+		{
+			manifest = new ProcessManifest("testAPKs/enriched1.apk");
+		} 
+		catch (IOException | XmlPullParserException e) 
+		{
+			e.printStackTrace();
+		}
+		
+		boolean throwsException = false;
+		
+		try
+		{
+			manifest.getVersionCode();
+			manifest.getMinSdkVersion();
+			manifest.targetSdkVersion();
+		}
+		catch (Exception ex)
+		{
+			throwsException = true;
+		}
+		
+		org.junit.Assert.assertFalse(throwsException);
+	}
+	
+	@Test
+	public void testSdkVersion()
+	{
+		ProcessManifest manifest = null;
+		
+		try 
+		{
+			manifest = new ProcessManifest("testAPKs/enriched1.apk");
+		} 
+		catch (IOException | XmlPullParserException e) 
+		{
+			e.printStackTrace();
+		}
+		
+		boolean throwsException = false;
+		
+		try
+		{
+			manifest.getMinSdkVersion();
+			manifest.targetSdkVersion();
+		}
+		catch (Exception ex)
+		{
+			throwsException = true;
+		}
+		
+		org.junit.Assert.assertFalse(throwsException);
+	}
+}


### PR DESCRIPTION
public int getVersionCode() throws java.lang.NullPointerException within the current version.
Because Integer.getInteger is not dedicated to transform a string to integer, but is for something else, cf. http://konigsberg.blogspot.in/2008/04/integergetinteger-are-you-kidding-me.html