### PR TITLE
Bugfix: Invalid resource index generated 

### DIFF
--- a/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
+++ b/src/soot/jimple/infoflow/android/resources/ARSCFileParser.java
@@ -1283,12 +1283,18 @@ public class ARSCFileParser extends AbstractResourceParser {
 							else
 								res.resourceName = "<INVALID RESOURCE>";
 							
-							AbstractResource r = resType.getResourceByName(res.resourceName);
-							if (r != null)
-								res.resourceID = r.resourceID;
-							if (res.resourceID <= 0)
+							if (res.resourceName != null && res.resourceName.length() > 0) {
+								// Some obfuscated resources do only contain an empty string as resource name
+								// -> We only need to check the name if it is really present
+								AbstractResource r = resType.getResourceByName(res.resourceName);
+								if (r != null) {
+									res.resourceID = r.resourceID;
+								}
+							}
+							if (res.resourceID <= 0) {
 								res.resourceID = (packageTable.id << 24)
 										+ (typeTable.id << 16) + resourceIdx;
+							}
 							config.resources.add(res);
 							resourceIdx++;
 						}


### PR DESCRIPTION
Bugfix: Invalid resource index generated for resources that have the resource name ""

Sample app: de.drivelog.connected v1.1.1